### PR TITLE
Fix for dev bigrquery

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,4 +22,4 @@ Depends: R (>= 3.3.2),
   assertthat,
   bigrquery,
   DBI
-RoxygenNote: 6.0.1.9000
+RoxygenNote: 7.2.3

--- a/R/run_pipeline.R
+++ b/R/run_pipeline.R
@@ -48,7 +48,7 @@ run_pipeline <- function(pipeline, parameters){
 #' @param pipeline User-provided function with one argument, one row of query results
 #' @param query A query to execute in Google BigQuery
 #' @param project The Google BigQuery project to bill
-#' @param ... Additional arguments passed to query_exec()
+#' @param ... Additional arguments passed to `bq_perform_query()`
 #'
 #' @import bigrquery
 #'
@@ -65,7 +65,7 @@ run_pipeline <- function(pipeline, parameters){
 #' options(httr_oob_default=TRUE)
 #'
 #' #Run the below query to authenticate and write credentials to .httr-oauth file
-#' query_exec("SELECT 'foo' as bar",project=project);
+#' bq_perform_query("SELECT 'foo' as bar",project);
 #'
 #' pipeline <- function(params){
 #'
@@ -79,9 +79,9 @@ run_pipeline <- function(pipeline, parameters){
 #'     GROUP BY repo_name
 #'   ;"
 #'
-#'   res <- query_exec(
+#'   res <- bq_perform_query(
 #'     whisker.render(query,params),
-#'     project=project,
+#'     project,
 #'     use_legacy_sql = FALSE
 #'   );
 #'
@@ -113,7 +113,7 @@ run_pipeline <- function(pipeline, parameters){
 run_pipeline_gbq <- function(pipeline, query, project, ... ){
 
   #run the query to generate the intitialization table
-  parameters <- query_exec(query, project=project, ...)
+  parameters <- bq_perform_query(query, project, ...)
 
   run_pipeline(pipeline, parameters)
 

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ options("httr_oauth_cache" = "~/.httr-oauth")
 options(httr_oob_default=TRUE)
 
 #Run the below query to authenticate and write credentials to .httr-oauth file
-query_exec("SELECT 'foo' as bar",project=project);
+bq_perform_query("SELECT 'foo' as bar",project);
 
 ```
 
@@ -185,8 +185,8 @@ pipeline <- function(params){
   LIMIT {{limit_size}}
   ;"
 
-  res <- query_exec(whisker.render(query,params),
-                    project=project,
+  res <- bq_perform_query(whisker.render(query,params),
+                    project,
                     use_legacy_sql = FALSE
   );
   
@@ -222,9 +222,9 @@ pipeline <- function(params){
     GROUP BY repo_name
   ;"
 
-  res <- query_exec(
+  res <- bq_perform_query(
     whisker.render(query,params),
-    project=project,
+    project,
     use_legacy_sql = FALSE
   );
   

--- a/man/run_pipeline_gbq.Rd
+++ b/man/run_pipeline_gbq.Rd
@@ -13,7 +13,7 @@ run_pipeline_gbq(pipeline, query, project, ...)
 
 \item{project}{The Google BigQuery project to bill}
 
-\item{...}{Additional arguments passed to query_exec()}
+\item{...}{Additional arguments passed to `bq_perform_query()`}
 }
 \description{
 A wrapper for running pipelines with a BigQuery invocation query
@@ -31,7 +31,7 @@ options("httr_oauth_cache" = "~/.httr-oauth")
 options(httr_oob_default=TRUE)
 
 #Run the below query to authenticate and write credentials to .httr-oauth file
-query_exec("SELECT 'foo' as bar",project=project);
+bq_perform_query("SELECT 'foo' as bar",project);
 
 pipeline <- function(params){
 
@@ -45,9 +45,9 @@ pipeline <- function(params){
     GROUP BY repo_name
   ;"
 
-  res <- query_exec(
+  res <- bq_perform_query(
     whisker.render(query,params),
-    project=project,
+    project,
     use_legacy_sql = FALSE
   );
 
@@ -57,8 +57,8 @@ pipeline <- function(params){
 run_pipeline_gbq(pipeline, "
   SELECT CONCAT('[',
   STRING_AGG(
-    CONCAT('{\\"name\\":\\"',name,'\\",'
-      ,'\\"name_clean\\":\\"', REGEXP_REPLACE(name, r'[^[:alpha:]]', ''),'\\"}'
+    CONCAT('{\"name\":\"',name,'\",'
+      ,'\"name_clean\":\"', REGEXP_REPLACE(name, r'[^[:alpha:]]', ''),'\"}'
     )
   ),
   ']') as list


### PR DESCRIPTION
The long deprecated query_exec() function has been removed so I switched you to bq_perform_query(). Since it doesn't look like this is covered by your automated tests, I'd recommend you check by hand that I've done this correctly.